### PR TITLE
docs: add cross-platform CI testing evaluation for 3-OS x 3-agent matrix

### DIFF
--- a/docs/ci-testing-evaluation.md
+++ b/docs/ci-testing-evaluation.md
@@ -4,8 +4,11 @@
 
 Forgememo is a Python CLI tool (daemon + MCP server) that integrates with 5 AI
 coding agents (Claude Code, Gemini CLI, Codex, OpenCode, Copilot) across 3 OSes
-(macOS, Linux, Windows). We need to test installation, daemon lifecycle, hook
-integration, and MCP transport across a **3x3 matrix**:
+(macOS, Linux, Windows). This evaluation is scoped to the 3 agents with
+headless CI support (Claude Code, Gemini CLI, Codex) -- OpenCode and Copilot
+lack non-interactive CLI modes suitable for automated testing. We need to test
+installation, daemon lifecycle, hook integration, and MCP transport across a
+**3x3 matrix** (3 OSes x 3 agents):
 
 | | macOS | Linux | Windows |
 |---|---|---|---|
@@ -277,8 +280,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Install Forgememo
         run: pip install -e .
+
+      - name: Install Claude Code CLI
+        if: matrix.agent == 'claude-code'
+        run: npm i -g @anthropic-ai/claude-code@<pinned-version>
+
+      - name: Install Gemini CLI
+        if: matrix.agent == 'gemini-cli'
+        run: npm i -g @google/gemini-cli@<pinned-version>
+
+      - name: Install Codex CLI
+        if: matrix.agent == 'codex-cli'
+        run: npm i -g @openai/codex@<pinned-version>
 
       - name: Start daemon
         run: forgememo start --background


### PR DESCRIPTION
Evaluates GitHub Actions (current), Depot, Docker Sandboxes, Lima, and
other CI options for testing Forgememo across macOS/Linux/Windows with
Claude Code, Gemini CLI, and Codex agents. Recommends keeping GHA as
primary CI with incremental agent integration tests.

https://claude.ai/code/session_013rkNN64qZ25m7vCh13b77d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CI testing strategy covering cross-platform test matrix (macOS/Linux/Windows), AI agent integration patterns, and current CI baseline.
  * Evaluated infrastructure/runner options and agent capabilities, plus a tiered rollout with a recommended scheduled/manual weekly agent integration workflow and clear decision guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->